### PR TITLE
Make site_up include hostname in service tag

### DIFF
--- a/site_up.py
+++ b/site_up.py
@@ -32,7 +32,8 @@ def monitor_site(url):
             recent_failures = max(recent_failures - 1, 0)
             time.sleep(INTERVAL)
 
-        alerts.harold.heartbeat("monitor_%s" % tag, max(INTERVAL, TIMEOUT) * 2)
+        alerts.harold.heartbeat("monitor_%s_%s" % (tag, local_name),
+                                max(INTERVAL, TIMEOUT) * 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Then we can run one on harold's box and one on mon-01 and they won't confuse harold's watchdog.
