### PR TITLE
Change monitoring user for monitor-siteup.

### DIFF
--- a/upstart/monitor-siteup.conf
+++ b/upstart/monitor-siteup.conf
@@ -9,4 +9,4 @@ respawn
 respawn limit 10 5
 
 chdir /opt/monitors
-exec su -s /bin/bash -c '/opt/monitors/site_up.py $url' monitoring
+exec su -s /bin/bash -c '/opt/monitors/site_up.py $url' reddit-monitor


### PR DESCRIPTION
It was using a different user because it was only running on the harold box (linode). Fixed up so it'll run cleanly on both now so we can ditch the siteup perl scripts on mon-01.
