### PR TITLE
tallier: Add support for batched metrics in datagrams.

### DIFF
--- a/tallier.py
+++ b/tallier.py
@@ -403,14 +403,15 @@ class Sample:
     def parse(cls, datagram):
         """Parses a datagram into a list of Sample values."""
         samples = []
-        parts = datagram.split(':')
-        if parts:
-            key = cls._normalize_key(parts.pop(0))
-            for part in parts:
-                try:
-                    samples.append(cls._parse_part(key, part))
-                except ValueError:
-                    continue
+        for metric in datagram.splitlines():
+            parts = metric.split(':')
+            if parts:
+                key = cls._normalize_key(parts.pop(0))
+                for part in parts:
+                    try:
+                        samples.append(cls._parse_part(key, part))
+                    except ValueError:
+                        continue
         return samples
 
     @classmethod

--- a/tallier_test.py
+++ b/tallier_test.py
@@ -182,5 +182,12 @@ class SampleTest(unittest.TestCase):
         self.assertEquals(2, ss[1].value)
         self.assertEquals(3, ss[2].value)
 
+        multisample = tallier.Sample.parse('key1:1|c\nkey2:9|c')
+        self.assertEquals(2, len(multisample))
+        self.assertEquals('key1', multisample[0].key)
+        self.assertEquals('key2', multisample[1].key)
+        self.assertEquals(1, multisample[0].value)
+        self.assertEquals(9, multisample[1].value)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
From the etsy/statsd README:

> All metrics can also be batch send in a single UDP packet, separated by a newline character.

I think this is a useful feature to add so metrics that are sent at the end of each request can be batched up to reduce packet counts.
