### PR TITLE
Add support for front-compressed multisamples.

### DIFF
--- a/tallier.py
+++ b/tallier.py
@@ -417,7 +417,15 @@ class Sample:
     def parse(cls, datagram):
         """Parses a datagram into a list of Sample values."""
         samples = []
+        previous = ''
         for metric in datagram.splitlines():
+            if len(metric) > 2 and metric[0] == '^':
+                try:
+                    prefix_len = int(metric[1:3], 16)
+                except ValueError:
+                    continue
+                metric = previous[:prefix_len] + metric[3:]
+            previous = metric
             parts = metric.split(':')
             if parts:
                 key = cls._normalize_key(parts.pop(0))

--- a/tallier_test.py
+++ b/tallier_test.py
@@ -197,5 +197,17 @@ class SampleTest(unittest.TestCase):
         self.assertEquals(1, multisample[0].value)
         self.assertEquals(9, multisample[1].value)
 
+    def test_parse_decompression(self):
+        ss = tallier.Sample.parse('^03abc:1|c\n^02def:2|c\n^08:3|c')
+        self.assertEquals(4, len(ss))
+        self.assertEquals('abc', ss[0].key)
+        self.assertEquals(1, ss[0].value)
+        self.assertEquals('abdef', ss[1].key)
+        self.assertEquals(2, ss[1].value)
+        self.assertEquals('abdef', ss[2].key)
+        self.assertEquals(2, ss[2].value)
+        self.assertEquals('abdef', ss[3].key)
+        self.assertEquals(3, ss[3].value)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The encoding scheme is to use a '^' followed by two hexadecimal digits at the beginning of a line to repeat the prefix of the line before. For example:

```
stats.service_time.web.x:100|ms
^17y:200|ms
```

expands to:

```
stats.service_time.web.x:100|ms
stats.service_time.web.y:200|ms
```
